### PR TITLE
Use UART assigned to current HART in pic64gx_console_get (as in pic64gx_console_putc)

### DIFF
--- a/include/uart_helper.h
+++ b/include/uart_helper.h
@@ -36,7 +36,7 @@ extern "C" {
 
 int uart_putstring(int hartid, char *p);
 ssize_t uart_getline(char **pBuffer, size_t *pBufLen);
-bool uart_getchar(uint8_t *pbuf, int32_t timeout_sec, bool do_sec_tick);
+bool uart_getchar(int hartid, uint8_t *pbuf, int32_t timeout_sec, bool do_sec_tick);
 void uart_putc(int hartid, const char ch);
 
 void *HSS_UART_GetInstance(int hartid);

--- a/modules/misc/hss_memtest.c
+++ b/modules/misc/hss_memtest.c
@@ -58,7 +58,7 @@ static void log_error_(const int count, volatile void *ptr, const uint64_t value
 static bool check_if_interrupted(void)
 {
     uint8_t rx_char;
-    return (uart_getchar(&rx_char, 0, false) && ((rx_char == '\003') || (rx_char == '\033')));
+    return (uart_getchar(HSS_HART_E51, &rx_char, 0, false) && ((rx_char == '\003') || (rx_char == '\033')));
 }
 
 static uint64_t* HSS_MemTestAddressBus(volatile uint64_t *baseAddr, const size_t numBytes)

--- a/modules/misc/hss_progress.c
+++ b/modules/misc/hss_progress.c
@@ -65,7 +65,7 @@ bool HSS_ShowTimeout(char const * const msg, uint32_t timeout_sec, uint8_t *pRcv
     mHSS_PRINTF("Timeout in %u second%s\n", timeout_sec, timeout_sec == 1 ? "" : "s");
     mHSS_PUTC('.');
 
-    if (uart_getchar(pRcvBuf, timeout_sec, true)) {
+    if (uart_getchar(HSS_HART_E51, pRcvBuf, timeout_sec, true)) {
         mHSS_DEBUG_PRINTF(LOG_NORMAL, "Character %u pressed\n", *pRcvBuf);
 
         if (*pRcvBuf != 27) { // ESC => done

--- a/modules/misc/uart_helper.c
+++ b/modules/misc/uart_helper.c
@@ -149,7 +149,7 @@ ssize_t uart_getline(char **pBuffer, size_t *pBufLen)
     return result;
 }
 
-bool uart_getchar(uint8_t *pbuf, int32_t timeout_sec, bool do_sec_tick)
+bool uart_getchar(int hartid, uint8_t *pbuf, int32_t timeout_sec, bool do_sec_tick)
 {
     bool result = false;
     bool done = false;
@@ -161,7 +161,7 @@ bool uart_getchar(uint8_t *pbuf, int32_t timeout_sec, bool do_sec_tick)
 
     const HSSTicks_t timeout_ticks = timeout_sec * TICKS_PER_SEC;
 
-    mss_uart_instance_t *pUart = HSS_UART_GetInstance(HSS_HART_E51);
+    mss_uart_instance_t *pUart = HSS_UART_GetInstance(hartid);
 
     while (!done) {
         size_t received = MSS_UART_get_rx(pUart, rx_buff, 1u);

--- a/services/opensbi/platform.c
+++ b/services/opensbi/platform.c
@@ -242,10 +242,11 @@ static void pic64gx_console_putc(char ch)
 static int pic64gx_console_getc(void)
 {
     int result = GETC_EOF;
-    bool uart_getchar(uint8_t *pbuf, int32_t timeout_sec, bool do_sec_tick);
+    u32 hartid = current_hartid();
+    bool uart_getchar(int hartid, uint8_t *pbuf, int32_t timeout_sec, bool do_sec_tick);
 
     uint8_t rcvBuf;
-    if (uart_getchar(&rcvBuf, NO_BLOCK, FALSE)) {
+    if (uart_getchar(hartid, &rcvBuf, NO_BLOCK, FALSE)) {
         result = rcvBuf;
     }
 

--- a/services/tinycli/tinycli_service.c
+++ b/services/tinycli/tinycli_service.c
@@ -182,7 +182,7 @@ static void tinycli_readline_handler(struct StateMachine * const pMyMachine)
 
     static bool escapeActive = false;
 
-    if (uart_getchar(cBuf, 0, false)) {
+    if (uart_getchar(HSS_HART_E51, cBuf, 0, false)) {
 	if (escapeActive) {
 		switch (cBuf[0]) {
 		case '[':
@@ -353,7 +353,7 @@ static void tinycli_usbdmsc_handler(struct StateMachine * const pMyMachine)
 
     done = !USBDMSC_IsActive();
 
-    if (!done && (uart_getchar(cBuf, 0, false))) {
+    if (!done && (uart_getchar(HSS_HART_E51, cBuf, 0, false))) {
         done = (cBuf[0] == '\003') || (cBuf[0] == '\033');
     }
 

--- a/services/ymodem/hss_ymodem_loader.c
+++ b/services/ymodem/hss_ymodem_loader.c
@@ -165,7 +165,7 @@ void hss_loader_ymodem_loop(void)
 
         mHSS_PUTS(menuText);
 
-        if (uart_getchar(&rx_byte, -1, false)) {
+        if (uart_getchar(HSS_HART_E51, &rx_byte, -1, false)) {
             switch (rx_byte) {
 #if IS_ENABLED(CONFIG_SERVICE_QSPI)
             case '1':

--- a/services/ymodem/ymodem_protocol.c
+++ b/services/ymodem/ymodem_protocol.c
@@ -77,7 +77,7 @@ static int16_t getchar_with_timeout_(int32_t timeout_sec)
     uint8_t rx_byte = 0;
     int16_t result = 0;
 
-    bool retval = uart_getchar(&rx_byte, timeout_sec, false);
+    bool retval = uart_getchar(HSS_HART_E51, &rx_byte, timeout_sec, false);
 
     if (retval) {
         result = rx_byte;


### PR DESCRIPTION
# Description

While trying to port EDK II to the PIC64GX Curiosity Kit, I got the UEFI Shell to print on the UART assigned to HART 1, but I could not enter anything. It turned out that while pic64gx_console_putc() uses the current HART to determine the UART to print to, pic64gx_console_get() always uses HSS_HART_E51, as this was hard-coded in uart_getchar().
This change adds an "hartid" argument to uart_getchar(), just as uart_putc() already has. Most instances calling uart_getchar still give HSS_HART_E51 as the value, except pic64gx_console_get(), which now uses current_hartid().
This lead to a working Shell, printing and reading from the same UART.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran custom EDK-Build that utilizes OpenSBI to access the UART. Without the change the Shell could print, but not read. After the change printing and reading worked.

**Test Configuration**:
* Hardware: PIC64GX Curiosity Kit
* HSS version: 0.99.41

# Checklist:

- [X] I have reviewed my code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works
- [ ] I have added a maintainers file for any new board support

Signed-off-by: Stefan Krupop <stefan.krupop@christmann.info>